### PR TITLE
bionic: Let popen and system fall back to /sbin/sh

### DIFF
--- a/libc/include/paths.h
+++ b/libc/include/paths.h
@@ -37,6 +37,7 @@
 #ifndef _PATH_BSHELL
 #define	_PATH_BSHELL	"/system/bin/sh"
 #endif
+#define	_PATH_BSHELL2	"/sbin/sh"
 #define	_PATH_CONSOLE	"/dev/console"
 #define	_PATH_DEFPATH	"/sbin:/system/sbin:/system/bin:/system/xbin:/vendor/bin:/vendor/xbin"
 #define	_PATH_DEV	"/dev/"

--- a/libc/upstream-netbsd/lib/libc/gen/popen.c
+++ b/libc/upstream-netbsd/lib/libc/gen/popen.c
@@ -152,6 +152,8 @@ popen(const char *command, const char *type)
 		}
 
 		execl(_PATH_BSHELL, "sh", "-c", command, NULL);
+		if (errno == ENOENT)
+			execl(_PATH_BSHELL2, "sh", "-c", command, NULL);
 		_exit(127);
 		/* NOTREACHED */
 	}

--- a/libc/upstream-openbsd/lib/libc/stdlib/system.c
+++ b/libc/upstream-openbsd/lib/libc/stdlib/system.c
@@ -62,6 +62,8 @@ system(const char *command)
 	case 0:				/* child */
 		sigprocmask(SIG_SETMASK, &omask, NULL);
 		execve(_PATH_BSHELL, argp, environ);
+		if (errno == ENOENT)
+			execve(_PATH_BSHELL2, argp, environ);
 		_exit(127);
 	}
 


### PR DESCRIPTION
This allows recovery utilities such as minivold to work.

Change-Id: I2136b0ca4188b7b44416f5d79492fc006382d4ad